### PR TITLE
Added support fot CCS in ytpot

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ytopt/benchmark/
 ```
 
 # Install instructions
-The autotuning framework requires the following components: ConfigSpace, scikit-optimize, autotune, and ytopt. 
+The autotuning framework requires the following components: ConfigSpace, CConfigSpace, scikit-optimize, autotune, and ytopt.
 
 * We recommend creating isolated Python environments on your local machine using [conda](https://docs.conda.io/projects/conda/en/latest/index.html), for example:
 
@@ -51,6 +51,43 @@ cd configspace
 pip install -e .
 cd ..
 ```
+
+* Install [CConfigSpace](https://github.com/argonne-lcf/CCS.git):
+    * Prerequisites: `autotools` and the `gsl`
+        * Ubuntu
+          ```
+          sudo apt-get install autoconf automake libtool libgsl-dev
+          ```
+
+        * MacOS
+          ```
+          brew install autoconf automake libtool gsl
+          ```
+    * Build and Install the library and python bindings:
+      the `configure` command can take an optional `--prefix=` parameter to specify a
+      different install path than the default one (`/usr/local`). Depending on the
+      chosen location you may need elevated previleges to run `make install`.
+      ```
+      git clone git@github.com:argonne-lcf/CCS.git
+      cd CCS
+      ./autogen.sh
+      mkdir build
+      cd build
+      ../configure
+      make
+      make install
+      cd ../bindings/python
+      pip install parglare==0.12.0
+      pip install -e .
+      ```
+    * Setup environment:
+      in order for the python binding to find the CConfigSpace library, the path to
+      the library install location (`/usr/local/lib` by default) must be appended
+      to the `LD_LIBRARY_PATH` environment variable on Linux, while on MacOS the
+      `DYLD_LIBRARY_PATH` environment variable serves the same purpose. Alternatively
+      the `LIBCCONFIGSPACE_SO_` environment variable can be made to point to the installed
+      `libcconfigspace.so` file on Linux or to the installed `libcconfigspace.dylib`
+      on MacOS.
 
 * Install [scikit-optimize](https://github.com/deephyper/scikit-optimize.git):
 ```

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ cd ..
       `libcconfigspace.so` file on Linux or to the installed `libcconfigspace.dylib`
       on MacOS.
 
-* Install [scikit-optimize](https://github.com/deephyper/scikit-optimize.git):
+* Install [scikit-optimize](https://github.com/ytopt-team/scikit-optimize.git):
 ```
-git clone https://github.com/deephyper/scikit-optimize.git
+git clone https://github.com/ytopt-team/scikit-optimize.git
 cd scikit-optimize
 pip install -e .
 cd ..

--- a/ytopt/benchmark/loopopt-ccs/problem.py
+++ b/ytopt/benchmark/loopopt-ccs/problem.py
@@ -1,0 +1,56 @@
+import numpy as np
+from numpy import abs, cos, exp, mean, pi, prod, sin, sqrt, sum
+from autotune import TuningProblem
+from autotune.space import *
+
+import sys
+import cconfigspace as CSS
+from skopt.space import Real, Integer, Categorical
+
+cs = CCS.ConfigurationSpace(name = "loopopt-ccs")
+cs.rng.seed = 1234
+
+
+p1  = CCS.CategoricalHyperparameter(name='p1',  values=['None', '#pragma omp #p3', '#pragma omp target #p3', '#pragma omp target #p5', '#pragma omp #p4'])
+p3  = CCS.CategoricalHyperparameter(name='p3',  values=['None', '#parallel for #p4', '#parallel for #p6', '#parallel for #p7'])
+p4  = CCS.CategoricalHyperparameter(name='p4',  values=['None', 'simd'])
+p5  = CCS.CategoricalHyperparameter(name='p5',  values=['None', '#dist_schedule static', '#dist_schedule #p11'])
+p6  = CCS.CategoricalHyperparameter(name='p6',  values=['None', '#schedule #p10', '#schedule #p11'])
+p7  = CCS.CategoricalHyperparameter(name='p7',  values=['None', '#numthreads #p12'])
+p10 = CCS.CategoricalHyperparameter(name='p10', values=['static', 'dynamic'])
+p11 = CCS.OrdinalHyperparameter(name='p11', values=['1', '8', '16'])
+p12 = CCS.OrdinalHyperparameter(name='p12', values=['1', '8', '16'])
+
+cs.add_hyperparameters([p1, p3, p4, p5, p6, p7, p10, p11, p12])
+
+#make p3 an active parameter when p1 value is ...
+cs.set_condition(p3,  "p1 # ['#pragma omp #p3', '#pragma omp target #p3']")
+cs.set_condition(p5,  "p1 == '#pragma omp target #p5'")
+cs.set_condition(p4,  "p1 == '#pragma omp #p4' || p3 == '#parallel for #p4'")
+cs.set_condition(p6,  "p3 == '#parallel for #p6'")
+cs.set_condition(p7,  "p3 == '#parallel for #p7'")
+cs.set_condition(p11, "p5 == '#dist_schedule #p11' || p6 == '#schedule #p11'")
+cs.set_condition(p10, "p6 == '#schedule #p10'")
+cs.set_condition(p12, "p7 == '#numthreads #p12'")
+
+# problem space
+task_space = None
+
+input_space = cs
+
+output_space = Space([
+    Real(-inf, inf, name='y')
+])
+
+def myobj(point: dict):
+    s = np.random.uniform()
+    return s
+
+Problem = TuningProblem(
+    task_space=None,
+    input_space=input_space,
+    output_space=output_space,
+    objective=myobj,
+    constraints=None,
+    model=None
+    )

--- a/ytopt/search/optimizer/optimizer.py
+++ b/ytopt/search/optimizer/optimizer.py
@@ -7,6 +7,7 @@ from skopt import Optimizer as SkOptimizer
 from ytopt.search import util
 
 import ConfigSpace as CS
+import cconfigspace as CCS
 
 logger = util.conf_logger('ytopt.search.hps.optimizer.optimizer')
 
@@ -25,7 +26,7 @@ class Optimizer:
 
         n_init = inf if learner=='DUMMY' else num_workers
 
-        if isinstance(self.space, CS.ConfigurationSpace):
+        if isinstance(self.space, CS.ConfigurationSpace) or isinstance(self.space, CCS.ConfigurationSpace):
             self._optimizer = SkOptimizer(
                 dimensions=self.space,
                 base_estimator=self.learner,
@@ -69,6 +70,12 @@ class Optimizer:
             hps_names = self.space.get_hyperparameter_names()
             for i in range(len(x)):
                 res[hps_names[i]] = x [i]
+            return res
+        elif isinstance(self.space, CCS.ConfigurationSpace):
+            res = {}
+            hps = self.space.hyperparameters
+            for i in range(len(x)):
+                res[hps[i].name] = x [i]
             return res
         else:
             return self.space.to_dict(x)


### PR DESCRIPTION
This pull request:
 - adds support for CCS in ytopt
 - adds a `loopopt-ccs` benchmark/test
 - updates the install instructions to cover CCS install on Linux and MacOS

To verify that everything is working fine, the following command can be used from the `ytopt/benchmark/loopopt-ccs` directory:
```
python -m ytopt.search.ambs --evaluator ray --problem problem.Problem --max-evals=5 --learner RF
```
The results should be similar to the ConfigSpace equivalent test.