### PR TITLE
New release for spack.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,9 +131,7 @@ setup(
     author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    # packages=find_packages(exclude=('tests',)),
-    # If your package is a single module, use this instead of 'packages':
-    py_modules=['ytopt'],
+    packages=find_packages(exclude=('test','build',)),
     entry_points={
         'console_scripts': [
             'ytopt-analytics=ytopt.core.logs.analytics:main'

--- a/ytopt/__version__.py
+++ b/ytopt/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (0, 0, 3)
+VERSION = (0, 0, 4)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
This PR fixes the python build system that was not picking up the ytopt files, resulting in empty pip installation.
This will require a new release in order for spack to get a valid version to work with.

Is the main branch ready for release otherwise? If so, I will create a new tag.